### PR TITLE
Fix #13828, Fix #17474: Fix retrieving inserted data for a primary ke…

### DIFF
--- a/framework/CHANGELOG.md
+++ b/framework/CHANGELOG.md
@@ -11,6 +11,8 @@ Yii Framework 2 Change Log
 - Bug #18051: Fix missing support for custom validation method in EachValidator (bizley)
 - Bug #18041: Fix RBAC migration for MSSQL (darkdef)
 - Bug #18081: Fix for PDO_DBLIB/MSSQL. Set flag ANSI_NULL_DFLT_ON to ON for current connect to DB (darkdef)
+- Bug #13828: Fix retrieving inserted data for a primary key of type uniqueidentifier for SQL Server 2005 or later (darkdef)
+- Bug #17474: Fix retrieving inserted data for a primary key of type trigger for SQL Server 2005 or later (darkdef)
 
 
 2.0.35 May 02, 2020

--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -437,10 +437,21 @@ class QueryBuilder extends \yii\db\QueryBuilder
 
     /**
      * {@inheritdoc}
+     * Added OUTPUT construction for getting inserted data (for SQL Server 2005 or later)
+     * OUTPUT clause - The OUTPUT clause is new to SQL Server 2005 and has the ability to access
+     * the INSERTED and DELETED tables as is the case with a trigger.
      */
     public function insert($table, $columns, &$params)
     {
-        return parent::insert($table, $this->normalizeTableRowData($table, $columns, $params), $params);
+        $columns = $this->normalizeTableRowData($table, $columns, $params);
+
+        $version2005orLater = version_compare($this->db->getSchema()->getServerVersion(), '9', '>=');
+
+        list($names, $placeholders, $values, $params) = $this->prepareInsertValues($table, $columns, $params);
+        return 'INSERT INTO ' . $this->db->quoteTableName($table)
+            . (!empty($names) ? ' (' . implode(', ', $names) . ')' : '')
+            . (!empty($placeholders) ?
+                ($version2005orLater ? ' OUTPUT INSERTED.*' : '') . ' VALUES (' . implode(', ', $placeholders) . ')' : $values);
     }
 
     /**

--- a/framework/db/mssql/Schema.php
+++ b/framework/db/mssql/Schema.php
@@ -751,4 +751,33 @@ SQL;
 
         return parent::quoteColumnName($name);
     }
+
+    /**
+     * Retrieving inserted data from a primary key request of type uniqueidentifier (for SQL Server 2005 or later)
+     * {@inheritdoc}
+     */
+    public function insert($table, $columns)
+    {
+        $command = $this->db->createCommand()->insert($table, $columns);
+        if (!$command->execute()) {
+            return false;
+        }
+
+        $version2005orLater = version_compare($this->db->getSchema()->getServerVersion(), '9', '>=');
+        $inserted = $version2005orLater ? $command->pdoStatement->fetch() : [];
+
+        $tableSchema = $this->getTableSchema($table);
+        $result = [];
+        foreach ($tableSchema->primaryKey as $name) {
+            if ($tableSchema->columns[$name]->autoIncrement) {
+                $result[$name] = $this->getLastInsertID($tableSchema->sequenceName);
+                break;
+            }
+            // @see https://github.com/yiisoft/yii2/issues/13828 & https://github.com/yiisoft/yii2/issues/17474
+            $result[$name] = isset($inserted[$name]) ? $inserted[$name] :
+                (isset($columns[$name]) ? $columns[$name] : $tableSchema->columns[$name]->defaultValue);
+        }
+
+        return $result;
+    }
 }


### PR DESCRIPTION
…y for SQL Server 2005 or later

- Bug #13828: Fix retrieving inserted data for a primary key of type uniqueidentifier for SQL Server 2005 or later.
- Bug #17474: Fix retrieving inserted data for a primary key of type trigger for SQL Server 2005 or later.

The OUTPUT clause is new to SQL Server 2005 and has the ability to access the INSERTED and DELETED tables as is the case with a trigger.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Tests pass?   | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
